### PR TITLE
Added Necron's Handle drop from Necron and fixed crash in reforge anvil

### DIFF
--- a/src/main/java/net/kapitencraft/mysticcraft/gui/reforging_anvil/ReforgeAnvilMenu.java
+++ b/src/main/java/net/kapitencraft/mysticcraft/gui/reforging_anvil/ReforgeAnvilMenu.java
@@ -143,6 +143,9 @@ public class ReforgeAnvilMenu extends NoBEMenu<ReforgeAnvilMenu.ReforgeAnvilCont
 
         public String reforge(Player player) {
             ItemStack stack = getStack(false);
+            if (stack == null || stack.isEmpty()) {
+                return null;
+            }
             if (InventoryHelper.isCreativeMode(player) || InventoryHelper.hasInInventory(List.of(new ItemStack(Items.EMERALD, 5)), player) && Reforges.canBeReforged(stack)) {
                 if (!InventoryHelper.isCreativeMode(player)) InventoryHelper.removeFromInventory(new ItemStack(Items.EMERALD, 5), player);
                 return Reforges.applyRandom(false, stack).getRegistryName();

--- a/src/main/resources/data/mysticcraft/loot_modifiers/necrons_handle_add.json
+++ b/src/main/resources/data/mysticcraft/loot_modifiers/necrons_handle_add.json
@@ -1,0 +1,15 @@
+{
+  "type": "mysticcraft:add_item",
+  "conditions": [
+    {
+      "condition": "entity_properties",
+      "entity": "this",
+      "predicate": {
+        "type": "minecraft:wither",
+        "nbt": "{WitherType:Necron}"
+      }
+    }
+  ],
+  "chance": 0.1,
+  "item": "mysticcraft:necrons_handle"
+}


### PR DESCRIPTION
Added drop "necrons_handle" from Necron Wither with 10% chance and fixed a crash when there is no Item in the Reforge Anvil, but the reforge button is clicked.